### PR TITLE
Expose AdEMAMix parameters

### DIFF
--- a/main.py
+++ b/main.py
@@ -267,6 +267,11 @@ def build_optimizer(cfg, model):
         return AdEMAMix(
             params,
             lr=cfg.lr,
+            betas=list(cfg.get("betas", (0.9, 0.999, 0.9999))),
+            alpha=cfg.get("alpha", 2.0),
+            beta3_warmup=cfg.get("beta3_warmup", 1000),
+            alpha_warmup=cfg.get("alpha_warmup", 1000),
+            eps=cfg.get("eps", 1e-8),
             weight_decay=cfg.weight_decay,
         )
     else:

--- a/yamls/main/flex-bert-base.yaml
+++ b/yamls/main/flex-bert-base.yaml
@@ -109,8 +109,15 @@ scheduler:
 
 optimizer:
   name: AdEMAMix
-  lr: 1e-3 # Peak learning rate
-  weight_decay: 1.0e-5 # Amount of weight decay regularization
+  lr: 1e-2
+  betas:
+    - 0.9
+    - 0.999
+    - 0.9999
+  alpha: 2.0
+  beta3_warmup: 45
+  alpha_warmup: 45
+  weight_decay: 0.1
   filter_bias_norm_wd: true # If True, doesn't apply weight decay to norm layers and biases
 
 # algorithms:


### PR DESCRIPTION
## Summary
- expose all AdEMAMix hyperparameters when constructing optimizer
- configure flex-bert-base example to show custom AdEMAMix settings

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68454005cf18832ba3a52dd7512d25f5